### PR TITLE
Bump datatables to 1.10.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1339,19 +1339,19 @@
             }
         },
         "datatables.net": {
-            "version": "1.10.22",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.22.tgz",
-            "integrity": "sha512-ujn8GvkQIBYzYH54XY7OrI0Zb35TKRd9ABYfbnXgBfwTGIFT6UsmXrfHU5Yk+MSDoF0sDu2TB+31V6c+zUZ0Pw==",
+            "version": "1.10.24",
+            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.24.tgz",
+            "integrity": "sha512-CwXixvOdinvBCLXvcTloDinWiEM7Geaz+GwyjPrZL+MXIGPcLv4Op1bbWn8ErsI1JWMIWC8Cuf1rnDU2RrFV5w==",
             "requires": {
                 "jquery": ">=1.7"
             }
         },
         "datatables.net-bs4": {
-            "version": "1.10.22",
-            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.10.22.tgz",
-            "integrity": "sha512-si0eOiaKmuURURpXhPRba7b3vCZsVfJK8pfrlM5WtaOaCEBa62DG/S9guMxUBmcAmvEC3FA2CKc/iKya3gb9qg==",
+            "version": "1.10.24",
+            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.10.24.tgz",
+            "integrity": "sha512-NgjQMqCo5pg49c5TWsc78UYhcvWPAFkZ7qH4yKAb1e0eLNCAo+TLeaIsDiAPpcWwP7xpjdAmZIIbXDpspNTCkg==",
             "requires": {
-                "datatables.net": "1.10.22",
+                "datatables.net": "1.10.24",
                 "jquery": ">=1.7"
             }
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@fortawesome/fontawesome-free": "5.15.1",
         "bootstrap": "4.5.3",
         "chart.js": "2.9.4",
-        "datatables.net-bs4": "1.10.22",
+        "datatables.net-bs4": "^1.10.24",
         "jquery": "3.5.1",
         "jquery.easing": "^1.4.1"
     },


### PR DESCRIPTION
This commit updates datatables.net to 1.10.24 which addresses https://snyk.io/vuln/SNYK-JS-DATATABLESNET-598806